### PR TITLE
Make POSIX compatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-CFLAGS = -std=c99
+CFLAGS = -std=c99 -D_POSIX_C_SOURCE=199309L -Wall -pedantic
 PREFIX = /usr/local
 
 watch: src/watch.c

--- a/src/watch.c
+++ b/src/watch.c
@@ -9,6 +9,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <time.h>
+
 #include <fcntl.h>
 #include <sys/wait.h>
 
@@ -73,7 +75,13 @@ milliseconds(const char *str) {
 
 void
 mssleep(int ms) {
-  usleep(ms * 1000);
+  struct timespec req={0};
+  time_t sec=(int)(ms/1000);
+  ms=ms-(sec*1000);
+  req.tv_sec=sec;
+  req.tv_nsec=ms*1000000L;
+     while(nanosleep(&req,&req)==-1)
+         continue;
 }
 
 /*
@@ -109,7 +117,7 @@ main(int argc, const char **argv){
   int interval = DEFAULT_INTERVAL;
 
   int len = 0;
-  char *args[ARGS_MAX] = {};
+  char *args[ARGS_MAX] = {0};
 
   for (int i = 1; i < argc; ++i) {
     const char *arg = argv[i];


### PR DESCRIPTION
The current version does not compile without errors:

```
cc src/watch.c -std=c99 -o watch
src/watch.c: In function ‘mssleep’:
src/watch.c:76:3: warning: implicit declaration of function ‘usleep’ [-Wimplicit-function-declaration]
```

This comes from the fact that usleep is not specified on clean C but in POSIX instead. But furthermore, usleep is deprecated in POSIX, see `man usleep`:

> 4.3BSD, POSIX.1-2001.  POSIX.1-2001 declares this function obsolete; use nanosleep(2) instead.  POSIX.1-2008 removes the  specification of usleep().

The attached patch changes the following things:
- Turns warnings into errors
- Specifies that this code can only run on POSIX-Systems
- Uses `nanosleep` instead of `usleep`
