### PR TITLE
Fixed typo: help says version is '-V' but it was '-v'

### DIFF
--- a/src/watch.c
+++ b/src/watch.c
@@ -124,7 +124,7 @@ main(int argc, const char **argv){
     }
 
     // -V, --version
-    if (option("-v", "--version", arg)) {
+    if (option("-V", "--version", arg)) {
       printf("%s\n", VERSION);
       exit(1);
     }


### PR DESCRIPTION
As the title says: Mismatch between help and code.
