### PR TITLE
Stop parameter parsing after the first non-option

### DIFF
--- a/src/watch.c
+++ b/src/watch.c
@@ -116,27 +116,28 @@ main(int argc, const char **argv){
 
   int len = 0;
   char *args[ARGS_MAX];
+  unsigned int parseOptions = 1;
 
   for (int i = 1; i < argc; ++i) {
     const char *arg = argv[i];
 
     // -h, --help
-    if (option("-h", "--help", arg)) usage();
+    if (parseOptions && option("-h", "--help", arg)) usage();
 
     // -q, --quiet
-    if (option("-q", "--quiet", arg)) {
+    if (parseOptions && option("-q", "--quiet", arg)) {
       quiet = 1;
       continue;
     }
 
     // -V, --version
-    if (option("-v", "--version", arg)) {
+    if (parseOptions && option("-v", "--version", arg)) {
       printf("%s\n", VERSION);
       exit(1);
     }
 
     // -i, --interval <n>
-    if (option("-i", "--interval", arg)) {
+    if (parseOptions && option("-i", "--interval", arg)) {
       if (argc-1 == i) {
         fprintf(stderr, "\n  --interval requires an argument\n\n");
         exit(1);
@@ -157,6 +158,7 @@ main(int argc, const char **argv){
     }
 
     args[len++] = (char *) arg;
+    parseOptions = 0;
   }
 
   // <cmd>


### PR DESCRIPTION
With the current code it is not possible to make '-i' a parameter to the command executed.

For example does `watch ls -i` not work. The man-page of the original watch states clearly:

> Note that POSIX option processing is used (i.e., option processing stops at the first non-option argument).  This means that flags after command don't get interpreted by watch itself.

The patch changes the behavior.
