### PR TITLE
Allow pipes in commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-CFLAGS = -std=c99 -D_POSIX_C_SOURCE=199309L -Wall -pedantic
+CFLAGS = -std=c99 -D_POSIX_C_SOURCE=200809L -Wall -pedantic
 PREFIX = /usr/local
 
 watch: src/watch.c


### PR DESCRIPTION
The current implementation does not allow to specify pipes as commands.

So `watch 'ls | grep txt'` fails, even worse without a clear error-message:

```
waitpid(): No child processes
exit: 1
```

This comes from the fact that the old `watch` implementation uses the `system` function to execute the commands. This function uses a shell which handles the pipes. `execvp` does not support pipes in its commands, you would have to set them up by yourself.

The following patch changes some things:
- Per default execute thru `system`
- Add a `-x`/`--exec` flag which switches back to the old behaviour
- Output a correct error-message on `execvp` errors.

This makes watch more usable and more compliant to the original implementation.
