### PR TITLE
Non-zero'd malloc wreaking havoc in OS X 10.8

### DIFF
--- a/src/watch.c
+++ b/src/watch.c
@@ -131,7 +131,7 @@ length(char **strs) {
 char *
 join(char **strs, int len, char *val) {
   --len;
-  char *buf = malloc(length(strs) + len * strlen(val));
+  char *buf = calloc(1, length(strs) + len * strlen(val));
   char *str;
   while ((str = *strs++)) {
     strcat(buf, str);


### PR DESCRIPTION
So I changed it to calloc. Which, according to the Apple docs I was looking at zero'd memory. Haven't looked at C in a while though....

Should fix #12.
