### PR TITLE
Handle unknown options

### DIFF
--- a/src/watch.c
+++ b/src/watch.c
@@ -193,6 +193,9 @@ main(int argc, const char **argv){
       continue;
     }
 
+    // unknown option
+    if (arg[0] == '-') usage();
+
     // cmd args
     if (len == ARGS_MAX) {
       fprintf(stderr, "number of arguments exceeded %d\n", len);


### PR DESCRIPTION
Unknown options in the command line arguments are passed to `sh`. Fix this by terminating the program on an unknown option.
