### PR TITLE
watch.c: Use clibs/ms for better interval parsing (1m, 12y, 45s, etc.)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
 
-CFLAGS = -std=c99 -D_POSIX_C_SOURCE=199309L -Wall -pedantic -Wno-parentheses
+CFLAGS = -std=c99 -D_POSIX_C_SOURCE=200809L
+CFLAGS += -Wall -pedantic -Wno-parentheses -Ideps
 PREFIX ?= /usr/local
+SRC = src/watch.c
+DEPS = $(wildcard deps/*/*.c)
+OBJS = $(SRC:.c=.o) $(DEPS:.c=.o)
 
 all: watch
 
-watch: src/watch.c
-	$(CC) $< $(CFLAGS) -o $@
+watch: $(OBJS)
+	$(CC) $^ $(CFLAGS) -o $@
 
 install: watch
 	install watch $(PREFIX)/bin/watch
@@ -14,6 +18,6 @@ uninstall:
 	rm -f $(PREFIX)/bin/watch
 
 clean:
-	rm -f watch
+	rm -f watch $(OBJS)
 
 .PHONY: all clean install uninstall

--- a/deps/asprintf/asprintf.c
+++ b/deps/asprintf/asprintf.c
@@ -1,0 +1,65 @@
+
+/**
+ * `asprintf.c' - asprintf
+ *
+ * copyright (c) 2014 joseph werle <joseph.werle@gmail.com>
+ */
+
+#ifndef HAVE_ASPRINTF
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+#include "asprintf.h"
+
+int
+asprintf (char **str, const char *fmt, ...) {
+  int size = 0;
+  va_list args;
+
+  // init variadic argumens
+  va_start(args, fmt);
+
+  // format and get size
+  size = vasprintf(str, fmt, args);
+
+  // toss args
+  va_end(args);
+
+  return size;
+}
+
+int
+vasprintf (char **str, const char *fmt, va_list args) {
+  int size = 0;
+  va_list tmpa;
+
+  // copy
+  va_copy(tmpa, args);
+
+  // apply variadic arguments to
+  // sprintf with format to get size
+  size = vsnprintf(NULL, size, fmt, tmpa);
+
+  // toss args
+  va_end(tmpa);
+
+  // return -1 to be compliant if
+  // size is less than 0
+  if (size < 0) { return -1; }
+
+  // alloc with size plus 1 for `\0'
+  *str = (char *) malloc(size + 1);
+
+  // return -1 to be compliant
+  // if pointer is `NULL'
+  if (NULL == *str) { return -1; }
+
+  // format string with original
+  // variadic arguments and set new size
+  size = vsprintf(*str, fmt, args);
+  return size;
+}
+
+#endif

--- a/deps/asprintf/asprintf.h
+++ b/deps/asprintf/asprintf.h
@@ -1,0 +1,35 @@
+
+/**
+ * `asprintf.h' - asprintf.c
+ *
+ * copyright (c) 2014 joseph werle <joseph.werle@gmail.com>
+ */
+
+#ifndef HAVE_ASPRINTF
+#ifndef ASPRINTF_H
+#define ASPRINTF_H 1
+
+#include <stdarg.h>
+
+/**
+ * Sets `char **' pointer to be a buffer
+ * large enough to hold the formatted string
+ * accepting a `va_list' args of variadic
+ * arguments.
+ */
+
+int
+vasprintf (char **, const char *, va_list);
+
+/**
+ * Sets `char **' pointer to be a buffer
+ * large enough to hold the formatted
+ * string accepting `n' arguments of
+ * variadic arguments.
+ */
+
+int
+asprintf (char **, const char *, ...);
+
+#endif
+#endif

--- a/deps/asprintf/package.json
+++ b/deps/asprintf/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "asprintf",
+  "version": "0.0.3",
+  "repo": "littlstar/asprintf.c",
+  "description": "asprintf() implementation",
+  "keywords": ["asprintf", "sprintf", "alloc", "string"],
+  "src": ["asprintf.h", "asprintf.c"]
+}

--- a/deps/ms/ms.c
+++ b/deps/ms/ms.c
@@ -1,0 +1,145 @@
+
+//
+// ms.c
+//
+// Copyright (c) 2012 TJ Holowaychuk <tj@vision-media.ca>
+//
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include "asprintf/asprintf.h"
+#include "ms.h"
+
+// microseconds
+
+#define US_MSEC (long long) 1000
+#define US_SEC 1000 * US_MSEC
+#define US_MIN 60 * US_SEC
+#define US_HOUR 60 * US_MIN
+#define US_DAY 24 * US_HOUR
+#define US_WEEK 7 * US_DAY
+#define US_YEAR 52 * US_WEEK
+
+// milliseconds
+
+#define MS_SEC (long long)1000
+#define MS_MIN 60 * MS_SEC
+#define MS_HOUR 60 * MS_MIN
+#define MS_DAY 24 * MS_HOUR
+#define MS_WEEK 7 * MS_DAY
+#define MS_YEAR 52 * MS_WEEK
+
+/*
+ * Convert the given `str` representation to microseconds,
+ * for example "10ms", "5s", "2m", "1h" etc.
+ */
+
+long long
+string_to_microseconds(const char *str) {
+  size_t len = strlen(str);
+  long long val = strtoll(str, NULL, 10);
+  if (!val) return -1;
+  switch (str[len - 1]) {
+    case 's': return  'm' == str[len - 2] ? val * 1000 : val * US_SEC;
+    case 'm': return val * US_MIN;
+    case 'h': return val * US_HOUR;
+    case 'd': return val * US_DAY;
+    case 'w': return val * US_WEEK;
+    case 'y': return val * US_YEAR;
+    default:  return val;
+  }
+}
+
+/*
+ * Convert the given `str` representation to milliseconds,
+ * for example "10ms", "5s", "2m", "1h" etc.
+ */
+
+long long
+string_to_milliseconds(const char *str) {
+  size_t len = strlen(str);
+  long long val = strtoll(str, NULL, 10);
+  if (!val) return -1;
+  switch (str[len - 1]) {
+    case 's': return  'm' == str[len - 2] ? val : val * 1000;
+    case 'm': return val * MS_MIN;
+    case 'h': return val * MS_HOUR;
+    case 'd': return val * MS_DAY;
+    case 'w': return val * MS_WEEK;
+    case 'y': return val * MS_YEAR;
+    default:  return val;
+  }
+}
+
+/*
+ * Convert the given `str` representation to seconds.
+ */
+
+long long
+string_to_seconds(const char *str) {
+  long long ret = string_to_milliseconds(str);
+  if (-1 == ret) return ret;
+  return ret / 1000;
+}
+
+/*
+ * Convert the given `ms` to a string. This
+ * value must be `free()`d by the developer.
+ */
+
+char *
+milliseconds_to_string(long long ms) {
+  char *str = NULL;
+  long long div = 1;
+  char *fmt;
+
+  if (ms < MS_SEC) fmt = "%lldms";
+  else if (ms < MS_MIN) { fmt = "%llds"; div = MS_SEC; }
+  else if (ms < MS_HOUR) { fmt = "%lldm"; div = MS_MIN; }
+  else if (ms < MS_DAY) { fmt = "%lldh"; div = MS_HOUR; }
+  else if (ms < MS_WEEK) { fmt = "%lldd"; div = MS_DAY; }
+  else if (ms < MS_YEAR) { fmt = "%lldw"; div = MS_WEEK; }
+  else { fmt = "%lldy"; div = MS_YEAR; }
+  if (-1 == asprintf(&str, fmt, ms / div)) {
+    return NULL;
+  }
+
+  return str;
+}
+
+/*
+ * Convert the given `ms` to a long string. This
+ * value must be `free()`d by the developer.
+ */
+
+char *
+milliseconds_to_long_string(long long ms) {
+  long long div;
+  char *name;
+
+  char *str = NULL;
+
+  if (ms < MS_SEC) {
+    if (-1 == asprintf(&str, "less than one second")) return NULL;
+    return str;
+  }
+
+  if (ms < MS_MIN) { name = "second"; div = MS_SEC; }
+  else if (ms < MS_HOUR) { name = "minute"; div = MS_MIN; }
+  else if (ms < MS_DAY) { name = "hour"; div = MS_HOUR; }
+  else if (ms < MS_WEEK) { name = "day"; div = MS_DAY; }
+  else if (ms < MS_YEAR) { name = "week"; div = MS_WEEK; }
+  else { name = "year"; div = MS_YEAR; }
+
+  long long val = ms / div;
+  char *fmt = 1 == val
+    ? "%lld %s"
+    : "%lld %ss";
+
+  if (-1 == asprintf(&str, fmt, val, name)) {
+    return NULL;
+  }
+
+  return str;
+}

--- a/deps/ms/ms.h
+++ b/deps/ms/ms.h
@@ -1,0 +1,28 @@
+
+//
+// ms.h
+//
+// Copyright (c) 2012 TJ Holowaychuk <tj@vision-media.ca>
+//
+
+#ifndef MS_H
+#define MS_H 1
+
+// prototypes
+
+long long
+string_to_microseconds(const char *str);
+
+long long
+string_to_milliseconds(const char *str);
+
+long long
+string_to_seconds(const char *str);
+
+char *
+milliseconds_to_string(long long ms);
+
+char *
+milliseconds_to_long_string(long long ms);
+
+#endif // MS_H

--- a/deps/ms/package.json
+++ b/deps/ms/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "ms",
+  "version": "0.0.4",
+  "repo": "clibs/ms",
+  "description": "String to microsecond & millisecond utilities",
+  "keywords": ["ms", "us", "usec", "millisecond", "microsecond", "conversion", "convert"],
+  "license": "MIT",
+  "src": ["ms.c", "ms.h"],
+  "dependencies": {
+    "littlstar/asprintf.c": "0.0.3"
+  }
+}


### PR DESCRIPTION
Closes #21.
