### PR TITLE
chore: bump version number for minor fix

### DIFF
--- a/src/watch.c
+++ b/src/watch.c
@@ -18,7 +18,7 @@
  * Command version.
  */
 
-#define VERSION "0.3.1"
+#define VERSION "0.4.0"
 
 /*
  * Default interval in milliseconds.


### PR DESCRIPTION
Noticed that the build version wasn't updated, so updated and bumped the minor up